### PR TITLE
Databasemigrator

### DIFF
--- a/appconfig/passwords/migrator.q
+++ b/appconfig/passwords/migrator.q
@@ -1,0 +1,1 @@
+migrator:pass

--- a/appconfig/process.csv
+++ b/appconfig/process.csv
@@ -21,3 +21,4 @@ localhost,{KDBBASEPORT}+18,metrics,metrics1
 localhost,{KDBBASEPORT}+19,iexfeed,iexfeed1
 localhost,{KDBBASEPORT}+20,checker,symcheck
 localhost,{KDBBASEPORT}+21,vtwap,vtwap1
+localhost,{KDBBASEPORT}+23,housekeeping,migrator1

--- a/code/processes/migrator.q
+++ b/code/processes/migrator.q
@@ -1,0 +1,32 @@
+\d .mig
+hdbtypes:@[value;`hdbtypes;`hdb];                                                               //list of hdb types to look for and call
+hdbnames:@[value;`hdbnames;()];                                                                 //list of hdb names to search for and call
+hdbconnsleepintv:@[value;`hdbconnsleepintv;10];                                                 //number of seconds between attempts to connect to the hdb
+
+if[not .timer.enabled;.lg.e[`migratorinit;
+   "the timer must be enabled to run the migrator process"]];                                   //if the timer is not enabled, then exit with error. Useful if want to migrate periodically
+
+nohdbconnected:{[]                                                                              //function to check that the hdb is connected to and subscription has been setup
+  :0 = count select from .sub.SUBSCRIPTIONS where proctype in .mig.hdbtypes, active;
+ };
+
+dates:"D"$.proc.params.dates;
+tablist:`$.proc.params.tablist;
+parpath:hsym `$.proc.params.parpath;
+
+\d .
+
+.servers.CONNECTIONS:(distinct .servers.CONNECTIONS,.mig.hdbtypes)except `rdb;                  //make sure that the process will make a connection to any process of hdb type
+.lg.o[`init;"searching for servers"];                                                           //and append connection results to logfile
+                                                                                                //drop rdb but leave disc for calls in case we need to migrate intraday data
+
+.servers.startup[];
+
+
+savetabledatepar:{
+  {
+   remotehdb:exec first w from .servers.SERVERS where proctype in `hdb;
+   set[x;remotehdb({[x;y]delete date from select from x where date =y};x;y)];
+   .Q.dpft[first .mig.parpath;y;`sym;x];
+   }\'[.mig.tablist;]each .mig.dates;
+ };

--- a/code/processes/migrator.q
+++ b/code/processes/migrator.q
@@ -13,6 +13,7 @@ nohdbconnected:{[]                                                              
 dates:"D"$.proc.params.dates;
 tablist:`$.proc.params.tablist;
 parpath:hsym `$.proc.params.parpath;
+.mig.sourcepath:.proc.params.sourcepath;
 
 \d .
 
@@ -22,11 +23,18 @@ parpath:hsym `$.proc.params.parpath;
 
 .servers.startup[];
 
-
-savetabledatepar:{
+databasesavetabledatepar:{                                                                      //function called to load source directory and save data to new partitions
   {
-   remotehdb:exec first w from .servers.SERVERS where proctype in `hdb;
-   set[x;remotehdb({[x;y]delete date from select from x where date =y};x;y)];
+    system "l ",raze .mig.sourcepath;
+    set[x;{[x;y]delete date from select from x where date=y}[x;y]];
+    .Q.dpft[first .mig.parpath;y;`sym;x];
+   }\'[.mig.tablist;]each .mig.dates;
+ };
+
+hdbsavetabledatepar:{                                                                           //function called to connect to hdb and save data to new partitions
+  {
+   remotehdb:exec first w from .servers.SERVERS where proctype in`hdb;
+   set[x;remotehdb({[x;y]delete date from select from x where date=y};x;y)];
    .Q.dpft[first .mig.parpath;y;`sym;x];
    }\'[.mig.tablist;]each .mig.dates;
  };

--- a/code/processes/migrator.q
+++ b/code/processes/migrator.q
@@ -8,44 +8,51 @@ if[not .timer.enabled;.lg.e[`migratorinit;
    "the timer must be enabled to run the migrator process"]];                                   //if the timer is not enabled, then exit with error. Useful if want to migrate periodically
 
 nohdbconnected:{[]                                                                              //function to check that the hdb is connected to and subscription has been setup
-  :0 = count select from .sub.SUBSCRIPTIONS where proctype in .mig.hdbtypes, active;
+  :0 = count select from .sub.SUBSCRIPTIONS where proctype in .mig.hdbtypes,active;
  };
 
 dates:"D"$.proc.params.dates;
 tablist:`$.proc.params.tablist;
 parpath:hsym `$.proc.params.parpath;
 sourcepath:.proc.params.sourcepath;
+pardirs:.proc.params.pardirs;
+
+parcreate:{
+  {system "echo ",x," >> ",(parpath,"par.txt;")}each pardirs;                                   //function creates par.txt and fills with designated partition directories
+ };
 
 databasesave:{                                                                                  //function called to load source directory and save data to new partitions
+  parcreate[];                                                                                  //create partition directories inside par.txt and save to parpath
   {
-    system "l ",raze sourcepath;
-    set[x;{[x;y]delete date from select from x where date=y}[x;y]];
-    .Q.dpft[first parpath;y;`sym;x];
+    system "l ",raze sourcepath;                                                                //load hdb directory
+    set[x;{[x;y]delete date from select from x where date=y}[x;y]];                             //assign x via set so can be used in .Q.dpft rather than explicit tablename
+    .Q.dpft[first parpath;y;`sym;x];                                                            //save data to directory containing par.txt
    }\'[tablist;]each dates;
  };
 
 hdbsave:{                                                                                       //function called to connect to hdb and save data to new partitions
+  parcreate[];                                                                                  //create partition directories inside par.txt and save to parpath
   {
-   remotehdb:exec first w from .servers.SERVERS where proctype in`hdb;
-   set[x;remotehdb({[x;y]delete date from select from x where date=y};x;y)];
-   .Q.dpft[first parpath;y;`sym;x];
+   remotehdb:exec first w from .servers.SERVERS where proctype in`hdb;                          //assign hdb handle to variable
+   set[x;remotehdb({[x;y]delete date from select from x where date=y};x;y)];                    //assign x via set as result of handle call
+   .Q.dpft[first parpath;y;`sym;x];                                                             //save data to directory containing par.txt
    }\'[tablist;]each dates;
  };
 
 \d .
 
-.servers.CONNECTIONS:(distinct .servers.CONNECTIONS,.mig.hdbtypes)except `rdb;                  //make sure that the process will make a connection to any process of hdb type
+.servers.CONNECTIONS:(distinct .servers.CONNECTIONS,.mig.hdbtypes)except`rdb;                   //make sure that the process will make a connection to any process of hdb type
 .lg.o[`init;"searching for servers"];                                                           //and append connection results to logfile
                                                                                                 //drop rdb but leave disc for calls in case we need to migrate intraday data
 
 .servers.startup[];
 
-if[`dbasesave in key .proc.params and not`hdbsave in key .proc.params;
+if[`dbasesave in key .proc.params and not`hdbsave in key .proc.params;                          //if present in cmdline and hdbsave not, run function then quit
   .mig.databasesave[];
   exit 0
  ];
 
-if[`hdbsave in key .proc.params and not`dbasesave in key .proc.params;
+if[`hdbsave in key .proc.params and not`dbasesave in key .proc.params;                          //if present in cmdline and dbasesave not, run function then quit
   .mig.hdbsave[];
   exit 0
- ];                                                                                             //if either present in cmdline, run corresponding function then quit
+ ]; 

--- a/code/processes/migrator.q
+++ b/code/processes/migrator.q
@@ -13,7 +13,9 @@ nohdbconnected:{[]                                                              
 dates:"D"$.proc.params.dates;
 tablist:`$.proc.params.tablist;
 parpath:hsym `$.proc.params.parpath;
-.mig.sourcepath:.proc.params.sourcepath;
+sourcepath:.proc.params.sourcepath;
+dstdp:"B"$first .proc.params.dstdp;
+hstdp:"B"$first .proc.params.hstdp;
 
 \d .
 
@@ -23,7 +25,7 @@ parpath:hsym `$.proc.params.parpath;
 
 .servers.startup[];
 
-databasesavetabledatepar:{                                                                      //function called to load source directory and save data to new partitions
+.mig.databasesavetabledatepar:{                                                                 //function called to load source directory and save data to new partitions
   {
     system "l ",raze .mig.sourcepath;
     set[x;{[x;y]delete date from select from x where date=y}[x;y]];
@@ -31,10 +33,13 @@ databasesavetabledatepar:{                                                      
    }\'[.mig.tablist;]each .mig.dates;
  };
 
-hdbsavetabledatepar:{                                                                           //function called to connect to hdb and save data to new partitions
+.mig.hdbsavetabledatepar:{                                                                      //function called to connect to hdb and save data to new partitions
   {
    remotehdb:exec first w from .servers.SERVERS where proctype in`hdb;
    set[x;remotehdb({[x;y]delete date from select from x where date=y};x;y)];
    .Q.dpft[first .mig.parpath;y;`sym;x];
    }\'[.mig.tablist;]each .mig.dates;
  };
+
+
+$[.mig.dstdp;.mig.databasesavetabledatepar[];.mig.hstdp;.mig.hdbsavetabledatepar[];];


### PR DESCRIPTION
This process takes arguments of tablist, dates, sourcepath, and parpath.

Tablist is a list of tables that will be migrated
dates is the date range that the tables will be migrated for
sourcepath is the source directory loaded by hdb processes
parpath is a directory containing par.txt

Sourcepath is used specifically by the function `databasesavetabledatepar` which loads the data in sourcepath, which is then saved to disk in partitions found in par.txt.

Parpath will contain partitions used by databasesavetabledatepar and hdbsavetabledatepar

The two aforementioned functions are called after starting the process to load and migrate data.

