### PR TITLE
PnL Engine

### DIFF
--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -142,6 +142,6 @@ upd:.rtsub.upd;
 .pnl.tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];                                                     / tph handle
 .timer.repeat[.z.p;0W;0D00:00:02;.pnl.refreshpnl;"refresh pnl"];                                                        / set refresh timer job
 .timer.repeat[.z.p+1000000000;0W;0D+`second$5;(.pnl.batchpost;.pnl.pnlbatch);"batch mode calculation"];                 / set batch timer job
-.timer.repeat["p"$.z.d+1;0W;1D;({x set 0#value x};`.pnl.shrttrade);"flush last trade value cache"];                             
+.timer.repeat["p"$.z.d+1;0W;1D;({x set 0#value x};'[`.pnl.shrttrade;`.pnl.pnlsnap]);"flush last trade value cache"];                             
 update active:not active from `.timer.timer where (`$description)=`$"batch mode calculation";                           / make batch timer job inactive by default
 

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -1,128 +1,116 @@
-changetotab:{[t;x]flip cols[t]!x}; 																														  / Flip list into correct table schema
+changetotab:{[t;x]flip cols[t]!x}; 											/ Flip list into correct table schema
 
-upd:{[t;x].wap.tabfuncs[t][t;changetotab[t;x]]};                                                / Replay Upd
+upd:{[t;x].wap.tabfuncs[t][t;changetotab[t;x]]};                                                			/ Replay Upd
 
 \d .wap
-tickerplanttypes:@[value;`tickerplanttypes;`tickerplant];                                       / List of tickerplant types to try and make a connection to
-replaylog:@[value;`replaylog;0b];                                                               / Replay the tickerplant log file
-schema:@[value;`schema;1b];                                                                     / Retrieve the schema from the tickerplant
-subscribeto:@[value;`subscribeto;`];	                                                          / A list of tables to subscribe to, default (`) means all tables
-subscribesyms:@[value;`subscribesyms;`];                                                        / A list of syms to subscribe for, (`) means all syms
-tpconnsleepintv:@[value;`tpconnsleepintv;10];                                                   / Number of seconds between attempts to connect to the tp
-summary:([sym:()]time:();price:();size:());                                                     / Summary table schema
-tabfuncs:()!();																																									/ Define dictionary for upd functions
+tickerplanttypes:@[value;`tickerplanttypes;`tickerplant];                                       			/ List of tickerplant types to try and make a connection to
+replaylog:@[value;`replaylog;0b];                                                               			/ Replay the tickerplant log file
+schema:@[value;`schema;1b];                                                                     			/ Retrieve the schema from the tickerplant
+subscribeto:@[value;`subscribeto;`];	                                                          			/ A list of tables to subscribe to, default (`) means all tables
+subscribesyms:@[value;`subscribesyms;`];                                                        			/ A list of syms to subscribe for, (`) means all syms
+tpconnsleepintv:@[value;`tpconnsleepintv;10];                                                   			/ Number of seconds between attempts to connect to the tp
+summary:([sym:()]time:();price:();size:());                                                     			/ Summary table schema
+tabfuncs:()!();														/ Define dictionary for upd functions
+
 tabfuncs[`trade`trade_iex]:{[t;x]@[`.wap.summary;asc([]sym:distinct x`sym);,';value exec (time;price;size) by sym from x];t insert x};
-tabfuncs[`srcquote`clienttrade]:{[t;x] if[.pnl.tickmode;.pnl.updtick[t;x]]};
+tabfuncs[`srcquote`clienttrade]:{[t;x] if[.pnl.tickmode;.pnl.upd[t;x]]};
 tabfuncs[`quote`quote_iex`pnltab]:{[t;x]t insert x};
 
 subscribe:{[]
   if[count s:.sub.getsubscriptionhandles[tickerplanttypes;();()!()];
     .lg.o[`subscribe;"found available tickerplant, attempting to subscribe"];                  
-    subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];                 / Call subscribe function and save info
-    @[`.wap;key subinfo;:;value subinfo];                                                       / Setting subtables and tplogdate globals
+    subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];                 			/ Call subscribe function and save info
+    @[`.wap;key subinfo;:;value subinfo];                                                       			/ Setting subtables and tplogdate globals
     ];
   };
 
-upd:{[t;x]tabfuncs[t][t;x]}; 																																		/ Generic upd
-																									
+upd:{[t;x]tabfuncs[t][t;x]}; 												/ Generic upd																									
 notpconnected:{0=count select from .sub.SUBSCRIPTIONS where proctype in .wap.tickerplanttypes,active};
 
 \d .pnl
 
-tickmode:@[value;`tickmode;1b];
-ticktime:@[value;`ticktime;`timestamp$0];
+tickmode:@[value;`tickmode;1b];												/ post mode
+ticktime:@[value;`ticktime;`timestamp$0];										/ last tick time
 
-shrtquote:([sym:`symbol$()]src:`symbol$();bid:`float$();ask:`float$());
-lngtrade:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`int$();position:`long$();dcost:`float$());
-shrttrade:`sym xkey lngtrade;
-/batchtrade:lngtrade;
-tsnap:lngtrade;
-idstp:0;
+shrtquote:([sym:`symbol$()]src:`symbol$();bid:`float$();ask:`float$());							/ last value cache quote table
+lngtrade:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`int$();			/ full trade records
+            position:`long$();dcost:`float$());
+shrttrade:`sym xkey lngtrade;												/ last value cache trade table 
+idstp:0;														/ trade id
+pnlsnap:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`int$();			/ pnl snapshot
+          position:`long$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();		
+          r:`float$();totpnl:`float$());
+pnlbatch:pnlsnap;													/ pnl batch
+pnltab:pnlsnap;														/ full pnl records ###remove in release version###
 
-pnltab:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`int$();position:`long$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();r:`float$();totpnl:`float$());
-pnlbatch:pnltab;
+getlast:{{?[null x;0;x]}@[shrttrade each x;y]};										/ function to get the last value from trade fields, .i.e last position/dcost
 
-getlast:{{?[null x;0;x]}@[shrttrade each x;y]};
-
-updtick:{[t;x]
+upd:{[t;x]														/ upd for pnl data
   if[t=`clienttrade;
-    .pnl.tsnap:update position:.pnl.getlast[sym;`position]+sums size*?[side=`BUY;1;-1],dcost:.pnl.getlast[sym;`dcost]+sums price*size*?[side=`BUY;-1;1] by sym from
-                 select time,sym,price,size,side,tid:.pnl.idstp+i from x;
-    lngtrade,:tsnap;
-    `.pnl.shrttrade upsert select by sym from tsnap;
-    .pnl.ticktime:first x`time;
-    pnlcalc[tsnap;shrtquote];
-    .pnl.idstp+:count tsnap;
+    tsnap:update position:.pnl.getlast[sym;`position]+sums size*?[side=`BUY;1;-1],					/ calculate required fields for pnl calculation
+                 dcost:.pnl.getlast[sym;`dcost]+sums price*size*?[side=`BUY;-1;1] by sym from
+            select time,sym,price,size,side,tid:.pnl.idstp+i from x;
+    lngtrade,:tsnap;													/ append trade snapshot to long records
+    `.pnl.shrttrade upsert select by sym from tsnap;									/ update last value cache trade table
+    .pnl.ticktime:first x`time;												
+    pnlcalc[tsnap;shrtquote];												/ push data to pnl calculator
+    .pnl.idstp+:count tsnap;												
    ];
   if[t=`srcquote;
-    `.pnl.shrtquote upsert `sym xkey select sym,src,bid,ask from select by sym from x;
+    `.pnl.shrtquote upsert `sym xkey select sym,src,bid,ask from select by sym from x;					/ update last value cache quote table ###update to BBO book for release###
     /pnlcalc[`time`sym xcols 0!shrttrade;quote];
    ];
  };
 
-/updbatch:{[t;x]
-/  if[t=`clienttrade;
-/    .pnl.tsnap:update position:.pnl.getlast[sym;`position]+sums size*?[side=`BUY;1;-1],dcost:.pnl.getlast[sym;`dcost]+sums price*size*?[side=`BUY;-1;1] by sym from
-/                 select time,sym,price,size,side,tid:.pnl.idstp+i from x;
-/    lngtrade,:tsnap;
-/    batchtrade,:tsnap;
-/    `.pnl.shrttrade upsert select by sym from tsnap;
-/    .pnl.idstp+:count tsnap;
-/   ];
-/  if[t=`srcquote;
-/    lngquote,:select sym,src,bid,ask from x;
-/   ];
-/ };
-
-pnlcalc:{[td;qt]
-  pnl:(count exec distinct sym from pnltab)_ update totpnl:sums r by sym from
+pnlcalc:{[td;qt]													/ function to calculate pnl
+  pnl:(count exec distinct sym from pnltab)_ update totpnl:sums r by sym from						
                 update r:0^first[r]^pnl-prev[pnl] by sym from
                   uj[`time`sym xcols 0!select by sym from pnltab;
                     update pnl:dcost+position*?[1=signum position;bid;ask]from lj[td;qt]];
-  pnltab,:pnl;
-  ?[tickmode;tph(`.u.upd;`pnltab;value flip pnl);.pnl.pnlbatch,:pnl];
- };
-
-batchpost:{[batch]
-  tph(`u.upd;`pnltab;value flip batch);
-  pnl.pnlbatch:0#pnlbatch;
- };
-
-modeswitch:{
-  .pnl.tickmode:not tickmode;
-  $[x>0;
-    (.timer.repeat[.z.p;0W;0D+`second$x;(batchpost;pnlbatch);"batch mode calculation"];
-    update active:0b from .timer.timer where (`$description)=`$"refresh pnl");
-    (.timer.remove select id from .timer.timer where (`$description)=`$"batch mode calculation";
-    update active:1b from .timer.timer where (`$description)=`$"refresh pnl");
+  pnltab,:pnl;														/ append to total pnl record
+  $[(.pnl.pnlsnap:pnl;													/ either save snapshot or batch up pnl
+     tickmode;tph(`.u.upd;`pnltab;value flip pnl));
+     .pnl.pnlbatch,:pnl;
    ];
  };
 
-refrpnl:{if[0D00:00:10<.z.p-ticktime;tph(`.u.upd;`pnltab;value flip pnl)]};
+batchpost:{[batch]													/ function to post batched data to TP
+  tph(`u.upd;`pnltab;value flip batch);
+  pnl.pnlbatch:0#pnlbatch;												/ empty batch table
+ };
+
+modeswitch:{[														/ function to switch between tick by tick and batch modes
+  .pnl.tickmode:not tickmode;	
+  update active:not active from .timer.timer where (`$description)in(`$"batch mode calculation")`$"refresh pnl"
+ };
+
+refrpnl:{if[0D00:00:10<.z.p-ticktime;tph(`.u.upd;`pnltab;value flip pnlsnap)]};						/ function to resend previous pnl tick
 
 \d .
 
 .servers.CONNECTIONS:distinct .servers.CONNECTIONS,.wap.tickerplanttypes;
 .lg.o[`init;"searching for servers"]; 
 .servers.startup[];
-.wap.subscribe[];                                                                               / Subscribe to the tickerplant
-while[                                                                                        	 / Check if the tickerplant has connected, block the process until a connection is established
+.wap.subscribe[];                                                                               			/ Subscribe to the tickerplant
+while[                                                                                        	 			/ Check if the tickerplant has connected, block the process until a connection is established
   .wap.notpconnected[];
-  .os.sleep .wap.tpconnsleepintv;                                                               / While no connected make the process sleep for X seconds and then run the subscribe function again
-  .servers.startup[];                                                                         	 / Run the servers startup code again (to make connection to discovery)
+  .os.sleep .wap.tpconnsleepintv;                       			                                        / While no connected make the process sleep for X seconds and then run the subscribe function again
+  .servers.startup[];                                                            		             	 	/ Run the servers startup code again (to make connection to discovery)
   .wap.subscribe[];
   ];
 
 upd:.wap.upd;
 
-.pnl.tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];
-if[.pnl.tickmode;.timer.repeat[.z.p;0W;0D00:00:02;.pnl.refrpnl;"refresh pnl"]];
+.pnl.tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];							/ tph handle
+.timer.repeat[.z.p;0W;0D00:00:02;.pnl.refrpnl;"refresh pnl"];								/ set refresh timer job
+.timer.repeat[.z.p+1000000000;0W;0D+`second$x;(batchpost;pnlbatch);"batch mode calculation"];				/ set batch timer job
+update active:not active from .timer.timer where (`$description)=`$"batch mode calculation";				/ make batch timer job inactive by default
 
-waps:{[syms;st;et]																																							/ Calculate time/volume weighted average price			
+waps:{[syms;st;et]													/ Calculate time/volume weighted average price			
   syms:(),syms;
   a:@'[x;i:{[x;y]x+til y-x}./:{[st;et;x]x bin (st;et)}[st;et;]each x:.wap.summary'[syms;`time]];
   :([]sym:syms;
-    vwap:wavg'[@'[.wap.summary'[syms;`size];i];                                                 / Calculate vwap
-    @'[.wap.summary'[syms;`price];i]];twap:wavg'[(next'[a]-a);@'[.wap.summary'[syms;`price];i]] / Calculate twap
+    vwap:wavg'[@'[.wap.summary'[syms;`size];i]; 			                                                / Calculate vwap
+    @'[.wap.summary'[syms;`price];i]];twap:wavg'[(next'[a]-a);@'[.wap.summary'[syms;`price];i]] 			/ Calculate twap
   );
  };

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -34,12 +34,12 @@ tickmode:@[value;`tickmode;1b];												/ post mode
 ticktime:@[value;`ticktime;`timestamp$0];										/ last tick time
 tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];
 
-shrtquote:([sym:`symbol$()]src:`symbol$();bid:`float$();ask:`float$());							/ last value cache quote table
-lngtrade:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();		/ full trade records
+shrtquote:([sym:`symbol$()]src:`symbol$();bid:`float$();ask:`float$();qid:`long$());					/ last value cache quote table
+lngtrade:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();qid:`long$();	/ full trade records
   position:`long$();dcost:`float$());
 shrttrade:`sym xkey lngtrade;												/ last value cache trade table 
 idstp:0;														/ trade id
-pnlsnap:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();			/ pnl snapshot
+pnlsnap:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();qid:`long$();	/ pnl snapshot
   position:`long$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();	
   r:`float$();totpnl:`float$());
 pnlbatch:pnlsnap;													/ pnl batch
@@ -60,7 +60,7 @@ updclientt:{[t;x]														/ upd for pnl data
  };
 
 updsrcq:{[t;x]
-  `.pnl.shrtquote upsert `sym xkey select sym,src,bid,ask from select by sym from x;					/ update last value cache quote table ###update to BBO book for release###
+  `.pnl.shrtquote upsert `sym xkey select sym,src,bid,ask,qid:0 from select by sym from x;				/ update last value cache quote table ###update to BBO book for release###
   /pnlcalc[`time`sym xcols 0!shrttrade;quote];
  };
 
@@ -72,7 +72,7 @@ pnlcalc:{[td;qt]													/ function to calculate pnl
   
   pnltab,:pnl;														/ append to total pnl record
   $[tickmode;
-    (pnl.pnlsnap:pnl;													/ either save snapshot or batch up pnl
+    (.pnl.pnlsnap:pnl;													/ either save snapshot or batch up pnl
     tph(`.u.upd;`pnltab;value flip pnl));
     pnlbatch,:pnl];
  };

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -11,7 +11,7 @@ subscribesyms:@[value;`subscribesyms;`];                                        
 tpconnsleepintv:@[value;`tpconnsleepintv;10];                                                   			/ Number of seconds between attempts to connect to the tp
 summary:([sym:()]time:();price:();size:());                                                     			/ Summary table schema
 tabfuncs:()!();														/ Define dictionary for upd functions
-
+															
 tabfuncs[`trade`trade_iex]:{[t;x]@[`.wap.summary;asc([]sym:distinct x`sym);,';value exec (time;price;size) by sym from x];t insert x};
 tabfuncs[`srcquote]:{[t;x].pnl.updsrcq[t;x]};
 tabfuncs[`clienttrade]:{[t;x].pnl.updclientt[t;x]};
@@ -34,8 +34,8 @@ tickmode:@[value;`tickmode;1b];												/ post mode
 ticktime:@[value;`ticktime;`timestamp$0];										/ last tick time
 tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];
 
-lngquote:([]time:`timestamp$();sym:`symbol$();src:`symbol$();bid:`float$();ask:`float$();qid:`long$());					/ last value cache quote table
-lngtrade:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();	/ full trade records
+lngquote:([]time:`timestamp$();sym:`symbol$();src:`symbol$();bid:`float$();ask:`float$();qid:`long$());			/ last value cache quote table
+lngtrade:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();		/ full trade records
   position:`long$();dcost:`float$());
 shrttrade:`sym xkey lngtrade;												/ last value cache trade table 
 shrtquote:`sym xkey lngquote;
@@ -44,17 +44,14 @@ pnlidstp:0;
 pnlsnap:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();qid:`long$();	/ pnl snapshot
   position:`long$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();	
   r:`float$();totpnl:`float$();pnlid:`long$());
-pnlbatch:pnlsnap;													/ pnl batch
-pnlsum:pnlsnap;
-pnltab:pnlsnap;														/ full pnl records ###remove in release version###
+pnlbatch:pnltab:pnlsnap;
 
-getlast:{{?[null x;0;x]}@[shrttrade each x;y]};										/ function to get the last value from trade fields, .i.e last position/dcost
+getlast:{0^shrttrade'[x]y};												/ function to get the last value from trade fields, .i.e last position/dcost
 
-updclientt:{[t;x]													/ upd for pnl data
-  tsnap:update position:.pnl.getlast[sym;`position]+sums size*?[side=`BUY;1;-1],					/ calculate required fields for pnl calculation
-  dcost:.pnl.getlast[sym;`dcost]+sums price*size*?[side=`BUY;-1;1] by sym from
+updclientt:{[t;x]				 									/ upd for pnl data
+  lngtrade,:tsnap:update position:.pnl.getlast[sym;`position]+sums size*?[side=`BUY;1;-1],				/ calculate required fields for pnl calculation
+    dcost:.pnl.getlast[sym;`dcost]+sums price*size*?[side=`BUY;-1;1] by sym from
     select time,sym,price,size,side,tid:.pnl.tidstp+i from x;
-  lngtrade,:tsnap;													/ append trade snapshot to long records
   `.pnl.shrttrade upsert select by sym from tsnap;									/ update last value cache trade table
   .pnl.ticktime:first x`time;												
   pnlcalc[tsnap;delete time from shrtquote];										/ push data to pnl calculator
@@ -62,26 +59,26 @@ updclientt:{[t;x]													/ upd for pnl data
  };
 
 updsrcq:{[t;x]
-  qsnap:select time,sym,src,bid,ask,qid:0 from select by sym from x;
-  lngquote,:qsnap;
+  lngquote,:qsnap:select time,sym,src,bid,ask,qid:0 from select by sym from x;
   `.pnl.shrtquote upsert `sym xkey qsnap;										/ update last value cache quote table ###update to BBO book for release###
   /pnlcalc[`time`sym xcols 0!shrttrade;quote];
  };
 
 pnlcalc:{[td;qt]													/ function to calculate pnl
+  pnl:uj[`time`sym xcols 0!select by sym from pnltab;
+        update pnl:0^dcost+position*?[1=signum position;bid;ask]from lj[td;qt]];
+
   pnl:update pnlid:.pnl.pnlidstp+i from
     (count exec distinct sym from pnltab)_ update totpnl:sums r from				    
-      update r:deltas pnl by sym from
-        uj[`time`sym xcols 0!select by sym from pnltab;
-          update pnl:0^dcost+position*?[1=signum position;bid;ask]from 
-            lj[td;qt]];
+      update r:deltas pnl by sym from pnl;
 
   pnltab,:pnl;	 													/ append to total pnl record
   pnlidstp+:count pnl;													
   $[tickmode;
     (.pnl.pnlsnap:pnl;													/ either save snapshot or batch up pnl
     tph(`.u.upd;`pnltab;value flip pnl));
-    pnlbatch,:pnl];
+    pnlbatch,:pnl
+   ];
  };
 
 setbatchtimer:{update period:0D+`second$x from `.timer.timer where (`$description)=`$"batch mode calculation"};		/ function to set batch post period
@@ -93,14 +90,14 @@ batchpost:{														/ function to post batched data to TP
 
 modeswitch:{														/ function to switch between tick by tick and batch modes
   .pnl.tickmode:not tickmode;	
-  update active:not active from `.timer.timer where (`$description)in(`$"batch mode calculation";`$"refresh pnl");
+  update active:not active from `.timer.timer where (`$description)in`$("batch mode calculation";"refresh pnl");
  };
 
-refreshpnl:{if[0D00:00:10<.z.p-ticktime;tph(`.u.upd;`pnltab;value flip pnlsnap)]};						/ function to resend previous pnl tick
+refreshpnl:{if[0D00:00:10<.z.p-ticktime;tph(`.u.upd;`pnltab;value flip pnlsnap)]};					/ function to resend previous pnl tick
 
 refrecord:{[id]
-  t:select ttime:time,sym,price,size,side,tid from lngtrade where tid=pnltab[`tid][id];
-  q:`sym xkey select qtime:time,sym,src,bid,ask,qid from lngquote where qid=pnltab[`qid][id];
+  t:select ttime:time,sym,price,size,side,tid from lngtrade where tid=pnltab[`tid]id;
+  q:`sym xkey select qtime:time,sym,src,bid,ask,qid from lngquote where qid=pnltab[`qid]id;
   :t lj q;
  };
 
@@ -122,6 +119,7 @@ upd:.wap.upd;
 .pnl.tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];							/ tph handle
 .timer.repeat[.z.p;0W;0D00:00:02;.pnl.refreshpnl;"refresh pnl"];							/ set refresh timer job
 .timer.repeat[.z.p+1000000000;0W;0D+`second$5;(.pnl.batchpost;.pnl.pnlbatch);"batch mode calculation"];			/ set batch timer job
+.timer.repeat["p"$.z.d+1;0W;1D;.pnl.shrttrade:0#.pnl.shrttrade);"flush last trade value cache"];
 update active:not active from `.timer.timer where (`$description)=`$"batch mode calculation";				/ make batch timer job inactive by default
 
 waps:{[syms;st;et]													/ Calculate time/volume weighted average price			

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -1,118 +1,112 @@
-changetotab:{[t;x]flip cols[t]!x}; 											/ Flip list into correct table schema
+changetotab:{[t;x]flip cols[t]!x};                                                                                      / Flip list into correct table schema
 
-upd:{[t;x].wap.tabfuncs[t][t;changetotab[t;x]]};                                                			/ Replay Upd
+upd:{[t;x].wap.tabfuncs[t][t;changetotab[t;x]]};                                                                        / Replay Upd
 
 \d .wap
-tickerplanttypes:@[value;`tickerplanttypes;`tickerplant];                                       			/ List of tickerplant types to try and make a connection to
-replaylog:@[value;`replaylog;0b];                                                               			/ Replay the tickerplant log file
-schema:@[value;`schema;1b];                                                                     			/ Retrieve the schema from the tickerplant
-subscribeto:@[value;`subscribeto;`];	                                                          			/ A list of tables to subscribe to, default (`) means all tables
-subscribesyms:@[value;`subscribesyms;`];                                                        			/ A list of syms to subscribe for, (`) means all syms
-tpconnsleepintv:@[value;`tpconnsleepintv;10];                                                   			/ Number of seconds between attempts to connect to the tp
-summary:([sym:()]time:();price:();size:());                                                     			/ Summary table schema
-tabfuncs:()!();														/ Define dictionary for upd functions
-															
+tickerplanttypes:@[value;`tickerplanttypes;`tickerplant];                                                               / List of tickerplant types to try and make a connection to
+replaylog:@[value;`replaylog;0b];                                                                                       / Replay the tickerplant log file
+schema:@[value;`schema;1b];                                                                                             / Retrieve the schema from the tickerplant
+subscribeto:@[value;`subscribeto;`];                                                                                    / A list of tables to subscribe to, default (`) means all tables
+subscribesyms:@[value;`subscribesyms;`];                                                                                / A list of syms to subscribe for, (`) means all syms
+tpconnsleepintv:@[value;`tpconnsleepintv;10];                                                                           / Number of seconds between attempts to connect to the tp
+summary:([sym:()]time:();price:();size:());                                                                             / Summary table schema
+tabfuncs:()!();                                                                                                         / Define dictionary for upd functions
+                                                                                                                        
 tabfuncs[`trade`trade_iex]:{[t;x]@[`.wap.summary;asc([]sym:distinct x`sym);,';value exec (time;price;size) by sym from x];t insert x};
-tabfuncs[`srcquote]:{[t;x].pnl.updsrcq[t;x]};
-tabfuncs[`clienttrade]:{[t;x].pnl.updclientt[t;x]};
+tabfuncs[`srcquote]:{[t;x].pnl.updsrcquote[t;x]};
+tabfuncs[`clienttrade]:{[t;x].pnl.updclienttrade[t;x]};
 tabfuncs[`quote`quote_iex`pnltab`pnltrade`pnlquote]:{[t;x](::)};
 
 subscribe:{[]
   if[count s:.sub.getsubscriptionhandles[tickerplanttypes;();()!()];
     .lg.o[`subscribe;"found available tickerplant, attempting to subscribe"];                  
-    subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];                 			/ Call subscribe function and save info
-    @[`.wap;key subinfo;:;value subinfo];                                                       			/ Setting subtables and tplogdate globals
+    subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];                                         / Call subscribe function and save info
+    @[`.wap;key subinfo;:;value subinfo];                                                                               / Setting subtables and tplogdate globals
     ];
   };
 
-upd:{[t;x]tabfuncs[t][t;x]}; 												/ Generic upd																									
+upd:{[t;x]tabfuncs[t][t;x]};                                                                                            / Generic upd                                                                                                                                                                                                   
 notpconnected:{0=count select from .sub.SUBSCRIPTIONS where proctype in .wap.tickerplanttypes,active};
 
 \d .pnl
 
-tickmode:@[value;`tickmode;1b];												/ post mode
-ticktime:@[value;`ticktime;`timestamp$0];										/ last tick time
-tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];								/ TP handle
+tickmode:@[value;`tickmode;1b];                                                                                         / post mode
+ticktime:@[value;`ticktime;`timestamp$0];                                                                               / last tick time
+tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];                                                          / TP handle
 
-shrtquote:([sym:`symbol$()]time:`timestamp$();src:`symbol$();bid:`float$();ask:`float$();bsize:`long$();asize:`long$();mode:`char$();ex:`char$();qid:`long$());
-shrttrade:([sym:`symbol$()]time:`timestamp$();price:`float$();size:`int$();side:`symbol$();position:`long$();dcost:`float$();tid:`long$());
-/shrttrade:`sym xkey flip`time`sym`price`size`size`position`dcost`tid!();
-/shrtquote:`sym xkey flip`time`sym`src`bid`ask`bsize`asize`mode`ex`qid!();
-tidstp:0;														/ trade id
-qidstp:0;														/ ### REMOVE IN RELEASE ###
-pnlidstp:0;														/ pnl id
-pnlsnap:([]time:`timestamp$();sym:`symbol$();tid:`long$();qid:`long$();pnlid:`long$();
-  position:`long$();dcost:`float$();pnl:`float$());
-pnlbatch:pnltab:pnlsnap;													
+shrtquote:([sym:`symbol$()]time:`timestamp$();src:`symbol$();bid:`float$();ask:`float$();bsize:`long$();                / last value cache quote table
+  asize:`long$();mode:`char$();ex:`char$();qid:`long$());
+shrttrade:([sym:`symbol$()]time:`timestamp$();price:`float$();size:`int$();side:`symbol$();position:`long$();           / last value cache trade table
+  dcost:`float$();tid:`long$());
+tidstp:qidstp:pnlidstp:0;                                                                                               / id stamps
+pnlbatch:pnlsnap:([]time:`timestamp$();sym:`symbol$();tid:`long$();qid:`long$();pnlid:`long$();position:`long$();       
+  dcost:`float$();pnl:`float$());                                                                                               
 
-getlast:{0^shrttrade'[x]y};												/ function to get the last value from trade fields, .i.e last position/dcost
+tppostback:{[t;x]tph(`.u.upd;t;value flip x)};                                                                          / function to post back to tickerplant
 
-updclientt:{[t;x]				 									/ upd for clienttrade table, calculates pnl
-  tsnap:ungroup update tid:.pnl.tidstp+i from 
+getlast:{0^shrttrade'[x]y};                                                                                             / function to get the last value from trade fields, .i.e last position/dcost
+
+updclienttrade:{[t;x]                                                                                                   / upd for clienttrade table, calculates pnl
+  tsnap:ungroup update tid:.pnl.tidstp+i from                                                                           / calculate required fields for pnl calculation
     select time:last time,price,size,side,position:last position,dcost:last dcost by sym from 
-    update position:.pnl.getlast[sym;`position]+sum size*?[side=`BUY;1;-1],						/ calculate required fields for pnl calculation
+    update position:.pnl.getlast[sym;`position]+sum size*?[side=`BUY;1;-1],                                             
     dcost:.pnl.getlast[sym;`dcost]+sum price*size*?[side=`BUY;-1;1] by sym from x;
  
-  .pnl.ticktime:last x`time;							
-  `.pnl.shrttrade upsert select by sym from tsnap;
-  pnlcalc[select by sym from tsnap;delete time from shrtquote];										/ push data to pnl calculator 			
-  tph(`.u.upd;`pnltrade;value flip `time`sym xcols tsnap);										/ post back trade table to TP with tid								
+  .pnl.ticktime:last x`time;                                                    
+  tppostback[`pnltrade;`time`sym xcols tsnap];                                                                          / post back trade table to TP with tid
+  `.pnl.shrttrade upsert tsnap:select by sym from tsnap;
+  pnlcalc[tsnap;delete time from shrtquote];                                                                            / push data to pnl calculator                                                           
   .pnl.tidstp+:count exec distinct tid from tsnap;
-  
  };
 
-updsrcq:{[t;x]														/ upd for srcquote table, calculates pnl
-  qsnap:update qid:.pnl.qidstp+i from x;						
-  `.pnl.shrtquote upsert select by sym from qsnap;										/ update last value cache quote table ###update to BBO book for release###
-  tph(`.u.upd;`pnlquote;value flip qsnap);										/ post back quote table to TP with qid
+updsrcquote:{[t;x]                                                                                                      / upd for srcquote table, calculates pnl
+  qsnap:update qid:.pnl.qidstp+i from x;                                                
+  `.pnl.shrtquote upsert select by sym from qsnap;                                                                      / update last value cache quote table ###update to BBO book for release###
+  tppostback[`pnlquote;qsnap];                                                                                          / post back quote table to TP with qid
   .pnl.qidstp+:count qsnap;
-  
-  /pnlcalc[`time`sym xcols 0!shrttrade;quote];
+  pnlcalc[shrttrade;shrtquote];                                                                                         / push data to pnl calculator
  };
 
-pnlcalc:{[td;qt]													/ function to calculate pnl
+pnlcalc:{[td;qt]                                                                                                        / function to calculate pnl
   pnl:select time,sym,tid,qid,pnlid,position,dcost,pnl from    
     update pnlid:.pnl.pnlidstp+i,pnl:0^dcost+position*?[1=signum position;bid;ask]from lj[td;qt];
- 
-  pnl,:select last time,sym:`TOTAL,pnlid:1+last pnlid,dcost:(0^last[.pnl.pnlsnap`dcost])+sum dcost,
+  pnl,:select last time,sym:`TOTAL,pnlid:1+last pnlid,dcost:(0^last[.pnl.pnlsnap`dcost])+sum dcost,                     / generate record for pseudosym TOTAL
     pnl:(0^last[.pnl.pnlsnap`pnl])+sum pnl from pnl;
  
-  .pnl.pnltab,:pnl;
-  .pnl.pnlidstp+:count pnl;													
-    $[tickmode;														/ either save snapshot or batch up pnl
-    (.pnl.pnlsnap:pnl;
-    tph(`.u.upd;`pnltab;value flip pnl));
+  .pnl.pnlidstp+:count pnl;                                                                                                     
+  $[tickmode;                                                                                                           / either save snapshot or batch up pnl
+    (.pnl.pnlsnap:pnl;tppostback[`pnltab;pnl]);
     pnlbatch,:pnl
    ];
  };
 
-setbatchtimer:{update period:0D+`second$x from `.timer.timer where (`$description)=`$"batch mode calculation"};		/ function to set batch post period
+setbatchtimer:{update period:0D+`second$x from `.timer.timer where (`$description)=`$"batch mode calculation"};         / function to set batch post period
 
-batchpost:{														/ function to post batched data to TP
-  tph(`.u.upd;`pnltab;value flip pnlbatch);
-  .pnl.pnlbatch:0#pnlbatch;												/ empty batch table
+batchpost:{                                                                                                             / function to post batched data to TP
+  tppostback[`pnltab;pnlbatch];
+  .pnl.pnlbatch:0#pnlbatch;                                                                                             / empty batch table
  };
 
-modeswitch:{														/ function to switch between tick by tick and batch modes
-  .pnl.tickmode:not tickmode;	
+modeswitch:{                                                                                                            / function to switch between tick by tick and batch modes
+  .pnl.tickmode:not tickmode;   
   update active:not active from `.timer.timer where (`$description)in`$("batch mode calculation";"refresh pnl");
  };
 
-refreshpnl:{if[0D00:00:10<.z.p-ticktime;tph(`.u.upd;`pnltab;value flip pnlsnap)]};					/ function to resend previous pnl tick
+refreshpnl:{if[0D00:00:10<.z.p-ticktime;tppostback[pnltab;pnlsnap]]};                                                   / function to resend previous pnl tick
 
-staticcalc:{[td;qt]													/ function for calculation of pnl for static date
+staticcalc:{[td;qt]                                                                                                     / function for calculation of pnl for static date
   pnl:aj[`sym`time;
     update position:sums size*?[side=`BUY;1;-1],dcost:sums price*size*?[side=`BUY;-1;1] by sym from
-    select time,sym,price,size,side,tid:.pnl.tidstp+i from td;
+      select time,sym,price,size,side,tid:.pnl.tidstp+i from td;
     select time,sym,src,bid,ask,qid:0 from qt
    ];
   :update pnlid:i from update totalpnl:sums r from update r:deltas pnl by sym from  
     update pnl:0^dcost+position*?[1=signum position;bid;ask]from pnl;
  };
 
-recreate:{[pt]														/ function to recreate pnl post-rollover
+recreate:{[pt]                                                                                                          / function to recreate pnl post-rollover
   hh:.servers.gethandlebytype[`hdb;`any];
-  :staticcalc[hh({select from `clienttrade where date=x};pt);hh({select from `srcquote where date=x};pt)];
+  :staticcalc .{x({[x;y]select from x where date=y};z;y)}[hh;pt]'[`clienttrade`srcquote];
  };
 
 \d .
@@ -120,28 +114,27 @@ recreate:{[pt]														/ function to recreate pnl post-rollover
 .servers.CONNECTIONS:distinct .servers.CONNECTIONS,.wap.tickerplanttypes;
 .lg.o[`init;"searching for servers"]; 
 .servers.startup[];
-.wap.subscribe[];                                                                               			/ Subscribe to the tickerplant
-while[                                                                                        	 			/ Check if the tickerplant has connected, block the process until a connection is established
+.wap.subscribe[];                                                                                                       / Subscribe to the tickerplant
+while[                                                                                                                  / Check if the tickerplant has connected, block the process until a connection is established
   .wap.notpconnected[];
-  .os.sleep .wap.tpconnsleepintv;                       			                                        / While no connected make the process sleep for X seconds and then run the subscribe function again
-  .servers.startup[];                                                            		             	 	/ Run the servers startup code again (to make connection to discovery)
+  .os.sleep .wap.tpconnsleepintv;                                                                                       / While no connected make the process sleep for X seconds and then run the subscribe function again
+  .servers.startup[];                                                                                                   / Run the servers startup code again (to make connection to discovery)
   .wap.subscribe[];
   ];
 
 upd:.wap.upd;
 
-.pnl.tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];							/ tph handle
-.timer.repeat[.z.p;0W;0D00:00:02;.pnl.refreshpnl;"refresh pnl"];							/ set refresh timer job
-.timer.repeat[.z.p+1000000000;0W;0D+`second$5;(.pnl.batchpost;.pnl.pnlbatch);"batch mode calculation"];			/ set batch timer job
-.timer.repeat["p"$.z.d+1;0W;1D;({x set 0#value x};'[(`.pnl.shrttrade;`.pnl.pnltrade;`.pnl.pnlquote)]);			/ set end of day flush of .pnl tables
-  "flush last trade value cache"];				
-update active:not active from `.timer.timer where (`$description)=`$"batch mode calculation";				/ make batch timer job inactive by default
+.pnl.tph:@[value;`tph;.servers.gethandlebytype[`tickerplant;`any]];                                                     / tph handle
+.timer.repeat[.z.p;0W;0D00:00:02;.pnl.refreshpnl;"refresh pnl"];                                                        / set refresh timer job
+.timer.repeat[.z.p+1000000000;0W;0D+`second$5;(.pnl.batchpost;.pnl.pnlbatch);"batch mode calculation"];                 / set batch timer job
+.timer.repeat["p"$.z.d+1;0W;1D;({x set 0#value x};`.pnl.shrttrade);"flush last trade value cache"];                             
+update active:not active from `.timer.timer where (`$description)=`$"batch mode calculation";                           / make batch timer job inactive by default
 
-waps:{[syms;st;et]													/ Calculate time/volume weighted average price			
+waps:{[syms;st;et]                                                                                                      / Calculate time/volume weighted average price                  
   syms:(),syms;
   a:@'[x;i:{[x;y]x+til y-x}./:{[st;et;x]x bin (st;et)}[st;et;]each x:.wap.summary'[syms;`time]];
   :([]sym:syms;
-    vwap:wavg'[@'[.wap.summary'[syms;`size];i]; 			                                                / Calculate vwap
-    @'[.wap.summary'[syms;`price];i]];twap:wavg'[(next'[a]-a);@'[.wap.summary'[syms;`price];i]] 			/ Calculate twap
+    vwap:wavg'[@'[.wap.summary'[syms;`size];i];                                                                         / Calculate vwap
+    @'[.wap.summary'[syms;`price];i]];twap:wavg'[(next'[a]-a);@'[.wap.summary'[syms;`price];i]]                         / Calculate twap
   );
  };

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -1,6 +1,6 @@
 changetotab:{[t;x]flip cols[t]!x};                                                                                      / Flip list into correct table schema
 
-upd:{[t;x].rtsub.tabfuncs[t][t;changetotab[t;x]]};                                                                        / Replay Upd
+upd:{[t;x].rtsub.tabfuncs[t][t;changetotab[t;x]]};                                                                      / Replay Upd
 
 \d .rtsub
 
@@ -130,10 +130,10 @@ recreate:{[pt]                                                                  
 .servers.CONNECTIONS:distinct .servers.CONNECTIONS,.rtsub.tickerplanttypes;
 .lg.o[`init;"searching for servers"]; 
 .servers.startup[];
-.rtsub.subscribe[];                                                                                                       / Subscribe to the tickerplant
+.rtsub.subscribe[];                                                                                                     / Subscribe to the tickerplant
 while[                                                                                                                  / Check if the tickerplant has connected, block the process until a connection is established
   .rtsub.notpconnected[];
-  .os.sleep .rtsub.tpconnsleepintv;                                                                                       / While no connected make the process sleep for X seconds and then run the subscribe function again
+  .os.sleep .rtsub.tpconnsleepintv;                                                                                     / While no connected make the process sleep for X seconds and then run the subscribe function again
   .servers.startup[];                                                                                                   / Run the servers startup code again (to make connection to discovery)
   .rtsub.subscribe[];
   ];

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -5,7 +5,7 @@ upd:{[t;x].rtsub.tabfuncs[t][t;changetotab[t;x]]};                              
 \d .rtsub
 
 tickerplanttypes:@[value;`tickerplanttypes;`tickerplant];                                                               / List of tickerplant types to try and make a connection to
-replaylog:@[value;`replaylog;0b];                                                                                       / Replay the tickerplant log file
+replaylog:@[value;`replaylog;1b];                                                                                       / Replay the tickerplant log file
 schema:@[value;`schema;1b];                                                                                             / Retrieve the schema from the tickerplant
 subscribeto:@[value;`subscribeto;`trade`trade_iex`srcquote`clienttrade];                                                                                    / A list of tables to subscribe to, default (`) means all tables
 subscribesyms:@[value;`subscribesyms;`];                                                                                / A list of syms to subscribe for, (`) means all syms
@@ -76,6 +76,10 @@ updsrcquote:{[t;x]                                                              
   tppostback[`pnlquote;qsnap];                                                                                          / post back quote table to TP with qid
   .pnl.qidstp+:count qsnap;
   pnlcalc[shrttrade;shrtquote];                                                                                         / push data to pnl calculator
+ };
+
+updbbo:{[t;x]                                                                                                           / placeholder function for BBO book upd
+  
  };
 
 pnlcalc:{[td;qt]                                                                                                        / function to calculate pnl

--- a/database.q
+++ b/database.q
@@ -4,5 +4,5 @@ quote_iex:([]time:`timestamp$(); sym:`g#`symbol$(); bid:`float$(); ask:`float$()
 trade_iex:([]time:`timestamp$(); sym:`g#`symbol$(); price:`float$(); size:`int$(); stop:`boolean$(); cond:`char$(); ex:`char$(); srctime:`timestamp$())
 srcquote:([]time:`timestamp$(); sym:`g#`symbol$(); src:`symbol$(); bid:`float$(); ask:`float$(); bsize:`long$(); asize:`long$(); mode:`char$(); ex:`char$())
 clienttrade:([]time:`timestamp$(); sym:`g#`symbol$(); price:`float$(); size:`int$();stop:`boolean$(); cond:`char$(); ex:`char$();side:`symbol$())
-pnltab:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();position:`int$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();r:`float$();totpnl:`float$())
+pnltab:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`int$();position:`int$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();r:`float$();totpnl:`float$())
 

--- a/database.q
+++ b/database.q
@@ -4,5 +4,6 @@ quote_iex:([]time:`timestamp$(); sym:`g#`symbol$(); bid:`float$(); ask:`float$()
 trade_iex:([]time:`timestamp$(); sym:`g#`symbol$(); price:`float$(); size:`int$(); stop:`boolean$(); cond:`char$(); ex:`char$(); srctime:`timestamp$())
 srcquote:([]time:`timestamp$(); sym:`g#`symbol$(); src:`symbol$(); bid:`float$(); ask:`float$(); bsize:`long$(); asize:`long$(); mode:`char$(); ex:`char$())
 clienttrade:([]time:`timestamp$(); sym:`g#`symbol$(); price:`float$(); size:`int$();stop:`boolean$(); cond:`char$(); ex:`char$();side:`symbol$())
-pnltab:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();position:`int$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();r:`float$();totpnl:`float$())
-
+pnltab:([]time:`timestamp$();sym:`symbol$();tid:`long$();qid:`long$();pnlid:`long$();position:`long$();dcost:`float$();pnl:`float$())
+pnltrade:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();position:`long$();dcost:`float$();tid:`long$())
+pnlquote:([]time:`timestamp$();sym:`symbol$();src:`symbol$();bid:`float$();ask:`float$();bsize:`long$();asize:`long$();mode:`char$();ex:`char$();qid:`long$())

--- a/database.q
+++ b/database.q
@@ -4,5 +4,5 @@ quote_iex:([]time:`timestamp$(); sym:`g#`symbol$(); bid:`float$(); ask:`float$()
 trade_iex:([]time:`timestamp$(); sym:`g#`symbol$(); price:`float$(); size:`int$(); stop:`boolean$(); cond:`char$(); ex:`char$(); srctime:`timestamp$())
 srcquote:([]time:`timestamp$(); sym:`g#`symbol$(); src:`symbol$(); bid:`float$(); ask:`float$(); bsize:`long$(); asize:`long$(); mode:`char$(); ex:`char$())
 clienttrade:([]time:`timestamp$(); sym:`g#`symbol$(); price:`float$(); size:`int$();stop:`boolean$(); cond:`char$(); ex:`char$();side:`symbol$())
-
+pnltab:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();position:`int$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();r:`float$();totpnl:`float$())
 

--- a/database.q
+++ b/database.q
@@ -4,5 +4,5 @@ quote_iex:([]time:`timestamp$(); sym:`g#`symbol$(); bid:`float$(); ask:`float$()
 trade_iex:([]time:`timestamp$(); sym:`g#`symbol$(); price:`float$(); size:`int$(); stop:`boolean$(); cond:`char$(); ex:`char$(); srctime:`timestamp$())
 srcquote:([]time:`timestamp$(); sym:`g#`symbol$(); src:`symbol$(); bid:`float$(); ask:`float$(); bsize:`long$(); asize:`long$(); mode:`char$(); ex:`char$())
 clienttrade:([]time:`timestamp$(); sym:`g#`symbol$(); price:`float$(); size:`int$();stop:`boolean$(); cond:`char$(); ex:`char$();side:`symbol$())
-pnltab:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`int$();position:`int$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();r:`float$();totpnl:`float$())
+pnltab:([]time:`timestamp$();sym:`symbol$();price:`float$();size:`int$();side:`symbol$();tid:`long$();position:`int$();dcost:`float$();src:`symbol$();bid:`float$();ask:`float$();pnl:`float$();r:`float$();totpnl:`float$())
 


### PR DESCRIPTION
PnL engine to calculate profit and loss tick by tick as trade/quote data comes through from the TP. This PnL data is then posted back to the TP either tick by tick or in batches according to what mode the process in running in.

Calculation is presently done using a last value cache for quote data, but will be redirected to use the BBO book that is being developed alongside the PnL engine.

This closes issue #10 